### PR TITLE
r-base 4.3.1: Rebuild with libtiff 4.7.0 (linux-64 only)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,8 +2,6 @@ aggregate_check: false
 
 upload_channels: [r]
 
-pbp_only_deployment: prod
-
 channels:
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,4 @@
 aggregate_check: false
+
+channels:
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,3 @@
 aggregate_check: false
 
 upload_channels: [r]
-
-channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
-

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,8 @@
 aggregate_check: false
 
-#upload_channels: [r]
+upload_channels: [r]
+
+pbp_only_deployment: prod
 
 channels:
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,6 @@
 aggregate_check: false
 
+#upload_channels: [r]
+
 channels:
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,5 +3,5 @@ aggregate_check: false
 upload_channels: [r]
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,4 +5,5 @@ upload_channels: [r]
 pbp_only_deployment: prod
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -201,27 +201,27 @@ test:
   files:
     - test-svg.R
   downstreams:
-    r-matrix  # 0 dependencies, compiled
-    r-rcpp  # 0 dependencies, compiled
-    r-data.table  # 0 dependencies, compiled
-    r-stringi  # 0 dependencies, compiled
-    r-ijtiff  # 1 dependency, compiled (uses libtiff)
-    r-ragg  # 1 dependency, compiled (uses libtiff)
-    r-gert  # 1 dependency, compiled
-    r-dplyr  # 2 dependencies, compiled
-    r-igraph  # 2 dependencies, compiled
-    r-rgl  # 2 dependencies, compiled
-    r-svglite  # 3 dependencies, compiled
-    r-patchwork  # 3 dependencies, noarch
-    r-ggplotify  # 4 dependencies, noarch
-    r-tidytree  # 5 dependencies, noarch
-    r-nlme  # 2 dependencies, compiled
-    r-caret  # 3 dependencies, compiled
-    r-purrr  # 3 dependencies, compiled
-    r-stringi  # 0 dependencies, compiled
-    r-readr  # 4 dependencies, compiled
-    r-mgcv  # 4 dependencies, compiled
-    r-survival  # 3 dependencies, compiled
+    - r-matrix  # 0 dependencies, compiled
+    - r-rcpp  # 0 dependencies, compiled
+    - r-data.table  # 0 dependencies, compiled
+    - r-stringi  # 0 dependencies, compiled
+    - r-ijtiff  # 1 dependency, compiled (uses libtiff)
+    - r-ragg  # 1 dependency, compiled (uses libtiff)
+    - r-gert  # 1 dependency, compiled
+    - r-dplyr  # 2 dependencies, compiled
+    - r-igraph  # 2 dependencies, compiled
+    - r-rgl  # 2 dependencies, compiled
+    - r-svglite  # 3 dependencies, compiled
+    - r-patchwork  # 3 dependencies, noarch
+    - r-ggplotify  # 4 dependencies, noarch
+    - r-tidytree  # 5 dependencies, noarch
+    - r-nlme  # 2 dependencies, compiled
+    - r-caret  # 3 dependencies, compiled
+    - r-purrr  # 3 dependencies, compiled
+    - r-stringi  # 0 dependencies, compiled
+    - r-readr  # 4 dependencies, compiled
+    - r-mgcv  # 4 dependencies, compiled
+    - r-survival  # 3 dependencies, compiled
 
 about:
   home: https://www.r-project.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -137,7 +137,7 @@ requirements:
     - {{native}}zlib 1.2.8               # [win]
     - {{native}}zlib                     # [not win]
     - {{native}}libtiff >=4.0.3,<4.0.8   # [win]
-    - {{native}}libtiff 4.7.0            # [not win]
+    - {{native}}libtiff {{ libtiff }}            # [not win]
     - {{native}}openblas-devel           # [not win]
     - {{native}}openblas                 # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -189,8 +189,8 @@ test:
     # TODO does not work on windows, because winCairo.dll is missing
     - Rscript test-svg.R                 # [not win]
     - open                               # [win]
-     # There doesn't seem to be a way to test this one
-     # - RSetReg                         # [win]
+    # There doesn't seem to be a way to test this one
+    # - RSetReg                         # [win]
     - Rfe --help                         # [win]
     - Rterm --help                       # [win]
     - Rterm --version                    # [win]
@@ -200,28 +200,6 @@ test:
     - if not exist %PREFIX%\\Lib\\R\\bin\\x64\\R.lib exit 1  # [win]
   files:
     - test-svg.R
-  downstreams:
-    - r-matrix
-    - r-rcpp
-    - r-data.table
-    - r-stringi
-    - r-ijtiff  # 1 dependency, compiled (uses libtiff)
-    - r-ragg  # 1 dependency, compiled (uses libtiff)
-    - r-gert
-    - r-dplyr
-    - r-igraph
-    - r-rgl
-    - r-svglite
-    - r-patchwork
-    - r-ggplotify
-    - r-tidytree
-    - r-nlme
-    - r-caret
-    - r-purrr
-    - r-stringi
-    - r-readr
-    - r-mgcv
-    - r-survival
 
 about:
   home: https://www.r-project.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
     - patches/0018-Use-sed-from-system.patch
 
 build:
-  skip: true  # [win]
+  skip: true  # [win or not (linux and x86_64)]
   merge_build_host: true  # [win]
   number: {{ build_number }}
   rpaths:
@@ -200,6 +200,28 @@ test:
     - if not exist %PREFIX%\\Lib\\R\\bin\\x64\\R.lib exit 1  # [win]
   files:
     - test-svg.R
+  downstreams:
+    r-matrix  # 0 dependencies, compiled
+    r-rcpp  # 0 dependencies, compiled
+    r-data.table  # 0 dependencies, compiled
+    r-stringi  # 0 dependencies, compiled
+    r-ijtiff  # 1 dependency, compiled (uses libtiff)
+    r-ragg  # 1 dependency, compiled (uses libtiff)
+    r-gert  # 1 dependency, compiled
+    r-dplyr  # 2 dependencies, compiled
+    r-igraph  # 2 dependencies, compiled
+    r-rgl  # 2 dependencies, compiled
+    r-svglite  # 3 dependencies, compiled
+    r-patchwork  # 3 dependencies, noarch
+    r-ggplotify  # 4 dependencies, noarch
+    r-tidytree  # 5 dependencies, noarch
+    r-nlme  # 2 dependencies, compiled
+    r-caret  # 3 dependencies, compiled
+    r-purrr  # 3 dependencies, compiled
+    r-stringi  # 0 dependencies, compiled
+    r-readr  # 4 dependencies, compiled
+    r-mgcv  # 4 dependencies, compiled
+    r-survival  # 3 dependencies, compiled
 
 about:
   home: https://www.r-project.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
     - patches/0018-Use-sed-from-system.patch
 
 build:
-  skip: true  # [win or not (linux and x86_64)]
+  skip: true  # [not (linux and x86_64)]
   merge_build_host: true  # [win]
   number: {{ build_number }}
   rpaths:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -154,7 +154,8 @@ requirements:
     - curl                               # [not win]
     - {{native}}bzip2                    # [win]
     - {{native}}libjpeg-turbo            # [win]
-    - {{native}}libiconv                 # [win]
+    # lib/R/lib/libR.so requires libiconv at runtime
+    - {{native}}libiconv
     - {{native}}gmp                      # [win]
     - {{native}}fftw                     # [win]
     - {{native}}xz                       # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set native = 'm2w64-' if win else '' %}
 {% set posix = 'm2-' if win else '' %}
 {% set version = "4.3.1" %}
-{% set build_number = "0" %}
+{% set build_number = "1" %}
 
 package:
   name: r-base
@@ -137,7 +137,7 @@ requirements:
     - {{native}}zlib 1.2.8               # [win]
     - {{native}}zlib                     # [not win]
     - {{native}}libtiff >=4.0.3,<4.0.8   # [win]
-    - {{native}}libtiff                  # [not win]
+    - {{native}}libtiff 4.7.0            # [not win]
     - {{native}}openblas-devel           # [not win]
     - {{native}}openblas                 # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -201,27 +201,27 @@ test:
   files:
     - test-svg.R
   downstreams:
-    - r-matrix  # 0 dependencies, compiled
-    - r-rcpp  # 0 dependencies, compiled
-    - r-data.table  # 0 dependencies, compiled
-    - r-stringi  # 0 dependencies, compiled
+    - r-matrix
+    - r-rcpp
+    - r-data.table
+    - r-stringi
     - r-ijtiff  # 1 dependency, compiled (uses libtiff)
     - r-ragg  # 1 dependency, compiled (uses libtiff)
-    - r-gert  # 1 dependency, compiled
-    - r-dplyr  # 2 dependencies, compiled
-    - r-igraph  # 2 dependencies, compiled
-    - r-rgl  # 2 dependencies, compiled
-    - r-svglite  # 3 dependencies, compiled
-    - r-patchwork  # 3 dependencies, noarch
-    - r-ggplotify  # 4 dependencies, noarch
-    - r-tidytree  # 5 dependencies, noarch
-    - r-nlme  # 2 dependencies, compiled
-    - r-caret  # 3 dependencies, compiled
-    - r-purrr  # 3 dependencies, compiled
-    - r-stringi  # 0 dependencies, compiled
-    - r-readr  # 4 dependencies, compiled
-    - r-mgcv  # 4 dependencies, compiled
-    - r-survival  # 3 dependencies, compiled
+    - r-gert
+    - r-dplyr
+    - r-igraph
+    - r-rgl
+    - r-svglite
+    - r-patchwork
+    - r-ggplotify
+    - r-tidytree
+    - r-nlme
+    - r-caret
+    - r-purrr
+    - r-stringi
+    - r-readr
+    - r-mgcv
+    - r-survival
 
 about:
   home: https://www.r-project.org/


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7602](https://anaconda.atlassian.net/browse/PKG-7602) 
- [Upstream repository]()

### Explanation of changes:

- Bump build number to 1
- Skip all platforms but linux-64
- Pin libtiff in host
- Use `{{native}}libiconv` on unix too because  `lib/R/lib/libR.so` requires it at runtime
- Test downstream packages, including those that depend on libtiff. I'll remove the list before merging.

### Notes:

- I'll rebuild `r-ijtiff` in another PR.

[PKG-7602]: https://anaconda.atlassian.net/browse/PKG-7602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ